### PR TITLE
For Arduino 1.6, skip huge WiFi/extras directory

### DIFF
--- a/ino/commands/build.py
+++ b/ino/commands/build.py
@@ -221,7 +221,7 @@ class Build(Command):
         flags = SpaceList()
         for d in libdirs:
             flags.append('-I' + d)
-            flags.extend('-I' + subd for subd in list_subdirs(d, recursive=True, exclude=['examples']))
+            flags.extend('-I' + subd for subd in list_subdirs(d, recursive=True, exclude=['examples', 'extras']))
         return flags
 
     def _scan_dependencies(self, dir, lib_dirs, inc_flags):


### PR DESCRIPTION
The directory /usr/share/arduino/libraries/WiFi/extras/ contains
a large number of subdirectories that will cause the generated
Makefile to include too many "-I" flags and overrun the command-
line length limit.