### PR TITLE
explicitly call python2.7 (extended temporary fix for #106)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ doc:
 	$(MAKE) -f doc/Makefile html
 
 install:
-	env python2 setup.py install --root $(DESTDIR) --prefix $(PREFIX) --exec-prefix $(PREFIX)
+	env python2.7 setup.py install --root $(DESTDIR) --prefix $(PREFIX) --exec-prefix $(PREFIX)
 
 .PHONY : doc
 .PHONY : install

--- a/bin/ino
+++ b/bin/ino
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 
 from ino.runner import main
 

--- a/ino/runner.py
+++ b/ino/runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 # -*- coding: utf-8; -*-
 
 """\


### PR DESCRIPTION
On MacOSX, for instance, there is no longer any python2 symlink present.